### PR TITLE
Fixed keeping pairing file in app after updating SideStore

### DIFF
--- a/AltStore/Operations/ResignAppOperation.swift
+++ b/AltStore/Operations/ResignAppOperation.swift
@@ -114,6 +114,7 @@ private extension ResignAppOperation
             
             infoDictionary[kCFBundleIdentifierKey as String] = profile.bundleIdentifier
             infoDictionary[Bundle.Info.altBundleID] = identifier
+            infoDictionary[Bundle.Info.devicePairingString] = Bundle.main.object(forInfoDictionaryKey: "ALTPairingFile") as? String
 
             for (key, value) in additionalInfoDictionaryValues
             {

--- a/Shared/Extensions/Bundle+AltStore.swift
+++ b/Shared/Extensions/Bundle+AltStore.swift
@@ -17,7 +17,7 @@ public extension Bundle
         public static let certificateID = "ALTCertificateID"
         public static let appGroups = "ALTAppGroups"
         public static let altBundleID = "ALTBundleIdentifier"
-        
+        public static let devicePairingString = "ALTPairingFile"
         public static let urlTypes = "CFBundleURLTypes"
         public static let exportedUTIs = "UTExportedTypeDeclarations"
         


### PR DESCRIPTION
Basically just reinsert the pairing file in the info.plist during the ResignAppOperation