### PR TITLE
Makes sure the ALTPairingFile gets transferred even if team IDs change

### DIFF
--- a/AltStore/Operations/ResignAppOperation.swift
+++ b/AltStore/Operations/ResignAppOperation.swift
@@ -173,6 +173,8 @@ private extension ResignAppOperation
                 if app.isAltStoreApp
                 {
                     guard let udid = Bundle.main.object(forInfoDictionaryKey: Bundle.Info.deviceID) as? String else { throw OperationError.unknownUDID }
+                    guard let pairingFileString = Bundle.main.object(forInfoDictionaryKey: Bundle.Info.AltPairingFile) as? String else { throw OperationError.unknownUDID }                    
+                    additionalValues[Bundle.Info.devicePairingString] = pairingFileString
                     additionalValues[Bundle.Info.deviceID] = udid
                     additionalValues[Bundle.Info.serverID] = UserDefaults.standard.preferredServerID
                     

--- a/AltStore/Operations/ResignAppOperation.swift
+++ b/AltStore/Operations/ResignAppOperation.swift
@@ -173,7 +173,7 @@ private extension ResignAppOperation
                 if app.isAltStoreApp
                 {
                     guard let udid = Bundle.main.object(forInfoDictionaryKey: Bundle.Info.deviceID) as? String else { throw OperationError.unknownUDID }
-                    guard let pairingFileString = Bundle.main.object(forInfoDictionaryKey: Bundle.Info.AltPairingFile) as? String else { throw OperationError.unknownUDID }                    
+                    guard let pairingFileString = Bundle.main.object(forInfoDictionaryKey: Bundle.Info.devicePairingString) as? String else { throw OperationError.unknownUDID }                    
                     additionalValues[Bundle.Info.devicePairingString] = pairingFileString
                     additionalValues[Bundle.Info.deviceID] = udid
                     additionalValues[Bundle.Info.serverID] = UserDefaults.standard.preferredServerID


### PR DESCRIPTION
Simple change to make sure that this (maybe more) edge case is taken care of.